### PR TITLE
Change to "Generate [faicon]" link

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -126,7 +126,7 @@ class Announcements extends React.PureComponent {
 			  [code]コード[/code]<br />
 			  [quote]引用[/quote]<br />
         [faicon]coffee[/faicon](<span class="fa fa-coffee"></span>の例)<br />
-        <a href="https://fontawesome.com/v4.7.0/icons/" target="_blank">faicon アイコン一覧</a>
+        <a href="https://yuzulabo.github.io/generate-faicon/" target="_blank">faiconを生成</a>
 			  </p>
             </div>
           </Collapsable>


### PR DESCRIPTION
公式の https://fontawesome.com/v4.7.0/icons/ から、私が作った https://yuzulabo.github.io/generate-faicon/ のリンクに変更しました。
faiconのコードが直接生成されるので使いやすいと思いますが、公式には検索にエイリアス`例: loadingと検索しても[fa-spinner](https://fontawesome.com/v4.7.0/icon/spinner/)が引っかかる` がついているのでメリットとデメリットがそれぞれある感じです。

どちらがいいか判断していただいた上でマージ/キャンセルしていただければと思います。