### PR TITLE
Toot button when navbar-under

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -527,3 +527,6 @@
     background: lighten($ui-highlight-color, 7%);
   }
 }
+.navbar-under .floating-action-button{
+  bottom: 3.4rem;
+}


### PR DESCRIPTION
ナビを画面下部に移動させる(モバイル レイアウトのみ)のときにトゥートボタンが被らなくていい感じになるはず